### PR TITLE
rails 3.2

### DIFF
--- a/lib/has_defaults.rb
+++ b/lib/has_defaults.rb
@@ -13,7 +13,7 @@ module SimplesIdeias
           include SimplesIdeias::Acts::Defaults::InstanceMethods
           
           unless respond_to?(:has_defaults_options)
-            class_inheritable_hash :has_defaults_options
+            class_attribute :has_defaults_options
           end
 
           self.has_defaults_options ||= {}


### PR DESCRIPTION
tests don't start due to /home/suung/workspace/development/has_defaults/spec/rails3/app_root/config/application.rb:30:in `<class:Application>': private method`new' called for Rails::Plugin:Class (NoMethodError)

but this change should be necessary, don't have the time to fight with the tests now.
