### PR TITLE
add license to gemspec

### DIFF
--- a/has_defaults.gemspec
+++ b/has_defaults.gemspec
@@ -5,6 +5,7 @@ Gem::Specification.new do |s|
   s.name = 'has_defaults'
   s.version = HasDefaults::VERSION
   s.authors = ["Henning Koch"]
+  s.licenses = ["MIT"]
   s.email = 'henning.koch@makandra.de'
   s.homepage = 'https://github.com/makandra/has_defaults'
   s.summary = 'Default values for ActiveRecord models.'


### PR DESCRIPTION
Having the license info in the gemspec helps generating a license report with `bundle license`
